### PR TITLE
Easier preprocessing pipeline

### DIFF
--- a/preprocessing/keypoint_extractor.py
+++ b/preprocessing/keypoint_extractor.py
@@ -1,0 +1,118 @@
+import os
+import argparse
+import cv2
+from deepface import DeepFace
+import face_alignment
+import numpy as np
+from tqdm import tqdm
+import sys
+
+
+def extract_frames(video_path):
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        print(f"Error: Cannot open video file {video_path}")
+        sys.exit(1)
+
+    frames = []
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    for _ in tqdm(range(total_frames), desc="Extracting frames"):
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        frames.append(frame_rgb)
+    cap.release()
+    return frames
+
+
+def detect_faces(frames, detector_backend='ssd'):
+    facial_areas = []
+    for frame in tqdm(frames, desc="Detecting faces"):
+        try:
+            faces = DeepFace.extract_faces(
+                img_path=None,
+                img=frame,
+                detector_backend=detector_backend,
+                align=False,
+                enforce_detection=False
+            )
+            areas = [face['facial_area'] for face in faces]
+            facial_areas.append(areas)
+        except Exception:
+            facial_areas.append([])
+    return facial_areas
+
+
+def extract_keypoints(frames, facial_areas, detector_backend='sfd', landmarks_type='2D', device='cuda'):
+    fa = face_alignment.FaceAlignment(
+        face_alignment.LandmarksType.TWO_D if landmarks_type.upper() == "2D" else face_alignment.LandmarksType.THREE_D,
+        device=device,
+        face_detector=detector_backend
+    )
+    keypoints = []
+    for idx in tqdm(range(len(frames)), desc="Extracting keypoints"):
+        frame = frames[idx]
+        faces = facial_areas[idx]
+        frame_keypoints = []
+        if not faces:
+            preds = fa.get_landmarks(frame)
+            frame_keypoints.append(preds[0] if preds else None)
+        else:
+            for face_roi in faces:
+                x1, y1, w, h = face_roi['x'], face_roi['y'], face_roi['w'], face_roi['h']
+                bounding_box = [x1, y1, x1 + w, y1 + h]
+                preds = fa.get_landmarks(frame, detected_faces=[bounding_box])
+                frame_keypoints.append(preds[0] if preds else None)
+        keypoints.append(frame_keypoints)
+    return keypoints
+
+
+def save_keypoints(keypoints, output_path):
+    # Convert list of lists to (num_frames, 68, 2), setting None to NaNs
+    processed_keypoints = []
+    for kp in keypoints:
+        if len(kp) > 0 and kp[0] is not None:
+            processed_keypoints.append(kp[0])
+        else:
+            # If no face detected, fill with NaNs
+            processed_keypoints.append(np.full((68, 2), np.nan))
+    np.save(output_path, np.array(processed_keypoints))
+    print(f"Keypoints saved to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect faces and extract keypoints from a video.")
+    parser.add_argument("--video_path", type=str, required=True, help="Path to the video file (.avi).")
+    parser.add_argument("--output_dir", type=str, required=True, help="Directory to save the output.")
+    args = parser.parse_args()
+
+    video_path = args.video_path
+    output_dir = args.output_dir
+
+    if not os.path.isfile(video_path):
+        print(f"Error: Video file '{video_path}' does not exist.")
+        sys.exit(1)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    frames = extract_frames(video_path)
+    print(f"Total frames extracted: {len(frames)}")
+
+    facial_areas = detect_faces(frames)
+    keypoints = extract_keypoints(frames, facial_areas)
+
+    video_name = os.path.splitext(os.path.basename(video_path))[0]
+    keypoints_output_path = os.path.join(output_dir, f"{video_name}.npy")
+    save_keypoints(keypoints, keypoints_output_path)
+
+    print("Keypoint extraction completed successfully.")
+
+
+if __name__ == "__main__":
+    main()
+
+"""
+Usage:
+    python keypoint_extractor.py --video_path /path/to/video.avi --output_dir /path/to/output
+"""

--- a/preprocessing/video_audio_converter.py
+++ b/preprocessing/video_audio_converter.py
@@ -1,0 +1,183 @@
+import os
+import argparse
+import subprocess
+import shutil
+import torchaudio
+import torch
+
+
+def check_ffmpeg_installed():
+    """Check if ffmpeg is installed on the system."""
+    if not shutil.which("ffmpeg"):
+        print("Error: ffmpeg is not installed or not found in PATH.")
+        exit(1)
+
+
+def convert_to_avi_no_audio(video_path, avi_output_path, fps=None):
+    """Convert a video to AVI format without audio."""
+    if fps is None:
+        cmd = [
+            "ffprobe",
+            "-v", "0",
+            "-of", "csv=p=0",
+            "-select_streams", "v:0",
+            "-show_entries", "stream=r_frame_rate",
+            video_path
+        ]
+        try:
+            result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            r_frame_rate = result.stdout.strip()
+            num, denom = r_frame_rate.split('/')
+            fps = float(num) / float(denom)
+        except Exception as e:
+            print(f"Error obtaining video fps: {e}")
+            exit(1)
+
+    # Convert to AVI (no audio)
+    command = [
+        "ffmpeg",
+        "-i", video_path,
+        "-c:v", "libxvid",
+        "-an",
+        "-r", str(fps),
+        avi_output_path,
+        "-y"
+    ]
+
+    try:
+        subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print(f"Video converted to AVI without audio and saved to {avi_output_path}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error converting video: {e.stderr.decode().strip()}")
+        exit(1)
+
+
+def extract_audio_from_mp4(mp4_path, audio_output_path, sample_rate=16000):
+    """Extract audio from the original MP4 and save it as WAV."""
+    command = [
+        "ffmpeg",
+        "-i", mp4_path,
+        "-vn",
+        "-acodec", "pcm_s16le",
+        "-ar", str(sample_rate),
+        "-ac", "1",
+        audio_output_path,
+        "-y"
+    ]
+
+    try:
+        print("Extracting audio from MP4...")
+        subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print(f"Audio extracted and saved to {audio_output_path}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error extracting audio: {e.stderr.decode().strip()}")
+        exit(1)
+
+
+def get_video_properties(avi_path):
+    """Retrieve FPS and frame count from the AVI video."""
+    cmd_fps = [
+        "ffprobe",
+        "-v", "0",
+        "-of", "csv=p=0",
+        "-select_streams", "v:0",
+        "-show_entries", "stream=r_frame_rate",
+        avi_path
+    ]
+    cmd_frames = [
+        "ffprobe",
+        "-v", "0",
+        "-count_frames",
+        "-select_streams", "v:0",
+        "-show_entries", "stream=nb_read_frames",
+        "-of", "csv=p=0",
+        avi_path
+    ]
+    try:
+        result_fps = subprocess.run(cmd_fps, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        r_frame_rate = result_fps.stdout.strip()
+        num, denom = r_frame_rate.split('/')
+        fps = float(num) / float(denom)
+    except Exception as e:
+        print(f"Error obtaining fps from AVI: {e}")
+        exit(1)
+
+    try:
+        result_frames = subprocess.run(cmd_frames, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        frame_count_str = result_frames.stdout.strip()
+        frame_count = int(frame_count_str)
+    except Exception as e:
+        print(f"Error obtaining frame count from AVI: {e}")
+        exit(1)
+
+    return fps, frame_count
+
+
+def pad_audio(audio_output_path, expected_samples, sample_rate=16000):
+    """Pad or trim audio to have exactly the expected number of samples."""
+    try:
+        audio, sr = torchaudio.load(audio_output_path)
+    except Exception as e:
+        print(f"Error loading audio for padding: {e}")
+        exit(1)
+
+    current_samples = audio.shape[1]
+    print(f"Current audio samples: {current_samples}, Expected samples: {expected_samples}")
+
+    if current_samples < expected_samples:
+        padding = expected_samples - current_samples
+        print(f"Padding audio with {padding} zeros.")
+        audio = torch.nn.functional.pad(audio, (0, padding))
+    elif current_samples > expected_samples:
+        trimming = current_samples - expected_samples
+        print(f"Trimming audio. Removing {trimming} samples.")
+        audio = audio[:, :expected_samples]
+
+    torchaudio.save(audio_output_path, audio, sample_rate)
+    print(f"Adjusted audio saved to {audio_output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert video to AVI without audio, extract audio from MP4, and add padding.")
+    parser.add_argument("--video_path", type=str, required=True, help="Path to the original video file.")
+    parser.add_argument("--output_dir", type=str, required=True, help="Directory to save output files.")
+    parser.add_argument("--sample_rate", type=int, default=16000, help="Sample rate for audio extraction (default: 16000).")
+    args = parser.parse_args()
+
+    video_path = args.video_path
+    output_dir = args.output_dir
+    sample_rate = args.sample_rate
+
+    check_ffmpeg_installed()
+
+    if not os.path.isfile(video_path):
+        print(f"Error: Video file '{video_path}' does not exist.")
+        exit(1)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    video_basename = os.path.basename(video_path)
+    video_name, _ = os.path.splitext(video_basename)
+
+    avi_output_path = os.path.join(output_dir, f"{video_name}.avi")
+    audio_output_path = os.path.join(output_dir, f"{video_name}.wav")
+
+    convert_to_avi_no_audio(video_path, avi_output_path)
+
+    fps, frame_count = get_video_properties(avi_output_path)
+    samples_per_frame = sample_rate // int(fps)
+    expected_samples = frame_count * samples_per_frame
+
+    extract_audio_from_mp4(video_path, audio_output_path, sample_rate=sample_rate)
+    pad_audio(audio_output_path, expected_samples, sample_rate=sample_rate)
+
+    print("Video conversion and audio extraction completed.")
+
+
+if __name__ == "__main__":
+    main()
+
+"""
+Usage:
+    python video_audio_converter.py --video_path /path/to/video.mp4 --output_dir /path/to/output --sample_rate 16000
+"""


### PR DESCRIPTION
Hi. Thanks for your work.

I've noticed in some of your experiments a lack of a simple inference script that integrates preprocessing steps like keypoint extraction. Maybe it might be worth considering adding one?

To give a draft on this, I added two small scripts to the preprocessing module. They are quite simple, but I think they might be useful for quick testing and experiments.

_keypoint_extractor.py_ extracts keypoints using deep face models to simplify model testing. It saves a .npy file with the same name as the input video, containing 68 landmarks (2 coordinates each) for each frame.

 Second one, _video_audio_converter.py_. handles MP4 to AVI conversion. Since this process can introduce small losses, I added padding or trimming to address minor discrepancies between audio and video durations.

So this way the entire preprocessing can be summarized on:
- (Optional) run video_audio_converter.py if you need to extract avi and wav files from a mp4 video.
-  Run keypoint_extractor.py to extract keypoints.
- Run crop_mouths.py to crop the mouth region. 

Ideally, these steps could be integrated into a single pipeline in the future, but for now, this serves as a quick draft for convenience. 


 